### PR TITLE
Feature/fix unix datetime models default legacy

### DIFF
--- a/models/action-log.js
+++ b/models/action-log.js
@@ -2,6 +2,7 @@
 
 var mongoose = require("mongoose");
 var Schema = mongoose.Schema;
+var retrieveCurrentUnixTime = require("./helperUtil").retrieveCurrentUnixTime;
 
 var modelSchema = new Schema({
   _id: {
@@ -29,7 +30,7 @@ var modelSchema = new Schema({
   },
   modified_unix_date: {
     type: Number,
-    default: Date.now
+    default: retrieveCurrentUnixTime
   }
 }, {
   collection: "massive_action_log"

--- a/models/action-log.js
+++ b/models/action-log.js
@@ -29,7 +29,7 @@ var modelSchema = new Schema({
   },
   modified_unix_date: {
     type: Number,
-    default: new Date().valueOf() / 1000.0
+    default: Date.now
   }
 }, {
   collection: "massive_action_log"

--- a/models/department.js
+++ b/models/department.js
@@ -105,7 +105,7 @@ var modelSchema = new Schema({
   },
   modified_unix_date: {
     type: Number,
-    default: new Date().valueOf() / 1000.0
+    default: Date.now
   },
 
   active: {

--- a/models/department.js
+++ b/models/department.js
@@ -3,6 +3,7 @@
 var mongoose = require("mongoose");
 var Schema = mongoose.Schema;
 var uuid = require("uuid");
+var retrieveCurrentUnixTime = require("./helperUtil").retrieveCurrentUnixTime;
 
 var Agency = require("./schema/cad-agency");
 
@@ -105,7 +106,7 @@ var modelSchema = new Schema({
   },
   modified_unix_date: {
     type: Number,
-    default: Date.now
+    default: retrieveCurrentUnixTime
   },
 
   active: {

--- a/models/helperUtil.js
+++ b/models/helperUtil.js
@@ -1,0 +1,9 @@
+"use strict";
+
+function retrieveCurrentUnixTime() {
+  return Date.now() / 1000;
+}
+
+module.exports = {
+  retrieveCurrentUnixTime: retrieveCurrentUnixTime
+};

--- a/models/incident-event.js
+++ b/models/incident-event.js
@@ -43,7 +43,7 @@ var modelSchema = new Schema({
   },
   modified_unix_date: {
     type: Number,
-    default: new Date().valueOf() / 1000.0
+    default: Date.now
   },
   message: {
     type: String,
@@ -66,7 +66,7 @@ var modelSchema = new Schema({
   },
   serverTime: {
     type: Number,
-    default: new Date().valueOf() / 1000.0,
+    default: Date.now,
     min: 1
   },
   userTime: {

--- a/models/incident-event.js
+++ b/models/incident-event.js
@@ -2,6 +2,7 @@
 
 var mongoose = require("mongoose");
 var Schema = mongoose.Schema;
+var retrieveCurrentUnixTime = require("./helperUtil").retrieveCurrentUnixTime;
 
 var EventUser = new Schema({
   username: {
@@ -43,7 +44,7 @@ var modelSchema = new Schema({
   },
   modified_unix_date: {
     type: Number,
-    default: Date.now
+    default: retrieveCurrentUnixTime
   },
   message: {
     type: String,
@@ -66,7 +67,7 @@ var modelSchema = new Schema({
   },
   serverTime: {
     type: Number,
-    default: Date.now,
+    default: retrieveCurrentUnixTime,
     min: 1
   },
   userTime: {

--- a/models/personnel-import.js
+++ b/models/personnel-import.js
@@ -2,6 +2,7 @@
 
 var mongoose = require("mongoose");
 var Schema = mongoose.Schema;
+var retrieveCurrentUnixTime = require("./helperUtil").retrieveCurrentUnixTime;
 
 var modelSchema = new Schema({
   _id: {
@@ -41,7 +42,7 @@ var modelSchema = new Schema({
   // Cases matches the other modified_unix_date
   modified_unix_date: {
     type: Number,
-    default: Date.now
+    default: retrieveCurrentUnixTime
   }
 }, {
   collection: "massive_personnel_import"

--- a/models/personnel-import.js
+++ b/models/personnel-import.js
@@ -41,7 +41,7 @@ var modelSchema = new Schema({
   // Cases matches the other modified_unix_date
   modified_unix_date: {
     type: Number,
-    default: new Date().valueOf() / 1000.0
+    default: Date.now
   }
 }, {
   collection: "massive_personnel_import"

--- a/models/user-device.js
+++ b/models/user-device.js
@@ -2,6 +2,7 @@
 
 var mongoose = require("mongoose");
 var Schema = mongoose.Schema;
+var retrieveCurrentUnixTime = require("./helperUtil").retrieveCurrentUnixTime;
 
 var deviceSchema = new Schema({
   token: {
@@ -18,7 +19,7 @@ var deviceSchema = new Schema({
   },
   time: {
     type: Number,
-    default: Date.now
+    default: retrieveCurrentUnixTime
   },
   bundleIdentifier: {
     type: String,

--- a/models/user-device.js
+++ b/models/user-device.js
@@ -18,7 +18,7 @@ var deviceSchema = new Schema({
   },
   time: {
     type: Number,
-    default: new Date().valueOf() / 1000.0
+    default: Date.now
   },
   bundleIdentifier: {
     type: String,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabletcommand-backend-models",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Tablet Command Backend Models",
   "scripts": {
     "test": "./node_modules/gulp/bin/gulp.js"


### PR DESCRIPTION
I think the fix is summed up in this guy's reply, and also explains the issues we were seeing with the timestamp: https://github.com/Automattic/mongoose/issues/3675#issuecomment-423473641

"As @brycelund pointed out, the schemaType default property can hold either a value or a function. If a value is set as the default, ie, the return of new Date() or Date.now(), then each subsequent doc created from this schema will receive the exact same default value that was set when the Schema was compiled into a model.

Alternatively, if the default is a function, like Date.now ( no parens means we're setting the default property to the function Date.now itself ) or () => { return 'xyz' }, then each doc will receive a new value from calling that function as it's default."
